### PR TITLE
Fix/node format

### DIFF
--- a/stn/config/config.py
+++ b/stn/config/config.py
@@ -82,7 +82,9 @@ class StaticRobustExecution(object):
             return
         risk_metric, dispatchable_graph = result
 
-        return risk_metric, dispatchable_graph
+        dispatchable_graph.risk_metric = risk_metric
+
+        return dispatchable_graph
 
 
 class DegreeStongControllability(object):
@@ -108,14 +110,16 @@ class DegreeStongControllability(object):
 
         stnu = dsc_lp.get_stnu(bounds)
 
-        # Returns a schedule because it is an offline approach
+        # The dispatchable graph is a schedule because it is an offline approach
         schedule = dsc_lp.get_schedule(bounds)
 
         # A strongly controllable STNU has a DSC of 1, i.e., a DSC value of 1 is better. We take
         # 1 − DC to be the risk metric, so that small values are preferable
         risk_metric = 1 - dsc
 
-        return risk_metric, schedule
+        schedule.risk_metric = risk_metric
+
+        return schedule
 
 
 class FullPathConsistency(object):
@@ -134,7 +138,10 @@ class FullPathConsistency(object):
         if dispatchable_graph is None:
             return
         risk_metric = 1
-        return risk_metric, dispatchable_graph
+
+        dispatchable_graph.risk_metric = risk_metric
+
+        return dispatchable_graph
 
 
 stn_factory = STNFactory()

--- a/stn/exceptions/stp.py
+++ b/stn/exceptions/stp.py
@@ -1,0 +1,6 @@
+class NoSTPSolution(Exception):
+
+    def __init__(self):
+        """ Raised when the stp solver cannot produce a solution for the problem
+        """
+        Exception.__init__(self)

--- a/stn/node.py
+++ b/stn/node.py
@@ -1,9 +1,13 @@
+from stn.utils.uuid import from_str
+
 
 class Node(object):
     """Represents a timepoint in the STN """
 
     def __init__(self, task_id, pose, node_type):
         # id of the task represented by this node
+        if isinstance(task_id, str):
+            task_id = from_str(task_id)
         self.task_id = task_id
         # Pose in the map where the node has to be executed
         self.pose = pose
@@ -30,7 +34,7 @@ class Node(object):
 
     def to_dict(self):
         node_dict = dict()
-        node_dict['task_id'] = self.task_id
+        node_dict['task_id'] = str(self.task_id)
         node_dict['pose'] = self.pose
         node_dict['node_type'] = self.node_type
         return node_dict
@@ -38,6 +42,8 @@ class Node(object):
     @staticmethod
     def from_dict(node_dict):
         task_id = node_dict['task_id']
+        if isinstance(task_id, str):
+            task_id = from_str(task_id)
         pose = node_dict['pose']
         node_type = node_dict['node_type']
         node = Node(task_id, pose, node_type)

--- a/stn/node.py
+++ b/stn/node.py
@@ -1,5 +1,3 @@
-from stn.utils.uuid import generate_uuid
-
 
 class Node(object):
     """Represents a timepoint in the STN """

--- a/stn/pstn/pstn.py
+++ b/stn/pstn/pstn.py
@@ -24,7 +24,6 @@
 
 from stn.pstn.constraint import Constraint
 from stn.stn import STN
-from stn.stn import Node
 from json import JSONEncoder
 import logging
 
@@ -48,7 +47,7 @@ class PSTN(STN):
             if self.has_edge(j, i) and i < j:
                 # Constraints with the zero timepoint
                 if i == 0:
-                    timepoint = Node.from_dict(self.nodes[j]['data'])
+                    timepoint = self.nodes[j]['data']
                     lower_bound = -self[j][i]['weight']
                     upper_bound = self[i][j]['weight']
                     to_print += "Timepoint {}: [{}, {}]".format(timepoint, lower_bound, upper_bound)
@@ -139,15 +138,15 @@ class PSTN(STN):
         """
         for (i, j) in constraints:
             self.logger.debug("Adding constraint: %s ", (i, j))
-            if self.nodes[i]['data']['node_type'] == "navigation":
+            if self.nodes[i]['data'].node_type == "navigation":
                 distribution = self.get_navigation_distribution(i, j)
                 self.add_constraint(i, j, distribution=distribution)
 
-            elif self.nodes[i]['data']['node_type'] == "start":
+            elif self.nodes[i]['data'].node_type == "start":
                 distribution = self.get_task_distribution(task)
                 self.add_constraint(i, j, distribution=distribution)
 
-            elif self.nodes[i]['data']['node_type'] == "finish":
+            elif self.nodes[i]['data'].node_type == "finish":
                 # wait time between finish of one task and start of the next one. Fixed to [0, inf]
                 self.add_constraint(i, j)
 

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -30,6 +30,8 @@ class STN(nx.DiGraph):
         super().__init__()
         self.add_zero_timepoint()
         self.max_makespan = MAX_FLOAT
+        self.risk_metric = None
+        self.temporal_metric = None
 
     def __str__(self):
         to_print = ""
@@ -122,7 +124,7 @@ class STN(nx.DiGraph):
         - finish: time at which the robot finishes executing the task
         """
         pose = self.get_node_pose(task, node_type)
-        node = Node(task.id, pose, node_type)
+        node = Node(task.task_id, pose, node_type)
         self.add_node(id, data=node.to_dict())
 
     def add_task(self, task, position=1):
@@ -142,7 +144,7 @@ class STN(nx.DiGraph):
         Note: Position 0 is reserved for the zero_timepoint
         Add tasks from postion 1 onwards
         """
-        self.logger.info("Adding task %s in position %s", task.id, position)
+        self.logger.info("Adding task %s in position %s", task.task_id, position)
 
         navigation_node_id = 2 * position + (position-2)
         start_node_id = navigation_node_id + 1
@@ -370,6 +372,16 @@ class STN(nx.DiGraph):
                 return 0
             else:
                 return float('inf')
+
+    def compute_temporal_metric(self, temporal_criterion):
+        if temporal_criterion == 'completion_time':
+            self.temporal_metric = self.get_completion_time()
+        elif temporal_criterion == 'makespan':
+            self.temporal_metric = self.get_makespan()
+        elif temporal_criterion == 'idle_time':
+            self.temporal_metric = self.get_idle_time()
+        else:
+            raise ValueError(temporal_criterion)
 
     def get_completion_time(self):
         nodes = list(self.nodes())

--- a/stn/stnu/stnu.py
+++ b/stn/stnu/stnu.py
@@ -1,5 +1,4 @@
 from stn.stn import STN
-from stn.stn import Node
 from json import JSONEncoder
 import logging
 
@@ -23,7 +22,7 @@ class STNU(STN):
             if self.has_edge(j, i) and i < j:
                 # Constraints with the zero timepoint
                 if i == 0:
-                    timepoint = Node.from_dict(self.nodes[j]['data'])
+                    timepoint = self.nodes[j]['data']
                     lower_bound = -self[j][i]['weight']
                     upper_bound = self[i][j]['weight']
                     to_print += "Timepoint {}: [{}, {}]".format(timepoint, lower_bound, upper_bound)
@@ -132,15 +131,15 @@ class STNU(STN):
         """
         for (i, j) in constraints:
             self.logger.debug("Adding constraint: %s ", (i, j))
-            if self.nodes[i]['data']['node_type'] == "navigation":
+            if self.nodes[i]['data'].node_type == "navigation":
                 lower_bound, upper_bound = self.get_navigation_bounded_duration(i, j)
                 self.add_constraint(i, j, lower_bound, upper_bound, is_contingent=True)
 
-            elif self.nodes[i]['data']['node_type'] == "start":
+            elif self.nodes[i]['data'].node_type == "start":
                 lower_bound, upper_bound = self.get_task_bounded_duration(task)
                 self.add_constraint(i, j, lower_bound, upper_bound, is_contingent=True)
 
-            elif self.nodes[i]['data']['node_type'] == "finish":
+            elif self.nodes[i]['data'].node_type == "finish":
                 # wait time between finish of one task and start of the next one. Fixed to [0, inf]
                 self.add_constraint(i, j, 0)
 

--- a/stn/stp.py
+++ b/stn/stp.py
@@ -1,5 +1,6 @@
 from stn.config.config import stn_factory, stp_solver_factory
 from stn.methods.fpc import get_minimal_network
+from stn.exceptions.stp import NoSTPSolution
 
 """ Solves a Simple Temporal Problem (STP)
 
@@ -48,19 +49,12 @@ class STP(object):
     def solve(self, stn):
         """ Computes the dispatchable graph and risk metric of the given stn
         """
-        result_stp = self.solver.compute_dispatchable_graph(stn)
-        return result_stp
+        dispatchable_graph = self.solver.compute_dispatchable_graph(stn)
 
-    @staticmethod
-    def compute_temporal_metric(dispatchable_graph, temporal_criterion):
-        if temporal_criterion == 'completion_time':
-            temporal_metric = dispatchable_graph.get_completion_time()
-        elif temporal_criterion == 'makespan':
-            temporal_metric = dispatchable_graph.get_makespan()
-        else:
-            raise ValueError(temporal_criterion)
+        if dispatchable_graph is None:
+            raise NoSTPSolution()
 
-        return temporal_metric
+        return dispatchable_graph
 
     @staticmethod
     def is_consistent(stn):

--- a/stn/task.py
+++ b/stn/task.py
@@ -1,5 +1,5 @@
 class STNTask(object):
-    def __init__(self, id,
+    def __init__(self, task_id,
                  r_earliest_navigation_start_time,
                  r_earliest_start_time,
                  r_latest_start_time,
@@ -19,7 +19,7 @@ class STNTask(object):
             hard_constraints (bool): False if the task can be
                                     scheduled ASAP, True if the task is not flexible. Defaults to True
         """
-        self.id = id
+        self.task_id = task_id
         self.r_earliest_navigation_start_time = round(r_earliest_navigation_start_time, 2)
         self.r_earliest_start_time = round(r_earliest_start_time, 2)
         self.r_latest_start_time = round(r_latest_start_time, 2)

--- a/stn/utils/uuid.py
+++ b/stn/utils/uuid.py
@@ -6,3 +6,10 @@ def generate_uuid():
     Returns a string containing a random uuid
     """
     return uuid.uuid4()
+
+
+def from_str(uuid_str):
+    """
+     Converts a uuid string to an uuid instance
+    """
+    return uuid.UUID(uuid_str)

--- a/test/scheduling_srea.py
+++ b/test/scheduling_srea.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     n_tasks = 3
     print("STN: ", stn)
 
-    alpha, dispatchable_graph = stp.solve(stn)
+    dispatchable_graph = stp.solve(stn)
     print("Guide: ", dispatchable_graph)
 
     schedule = get_schedule(dispatchable_graph, stn)

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,20 @@
+import json
+from stn.stp import STP
+STNU = "data/stnu_two_tasks.json"
+
+
+if __name__ == '__main__':
+    with open(STNU) as json_file:
+        stnu_dict = json.load(json_file)
+
+    # Convert the dict to a json string
+    stnu_json = json.dumps(stnu_dict)
+
+    stp = STP('dsc_lp')
+    stn = stp.get_stn(stn_json=stnu_json)
+
+    print(stn)
+    stn_dict = stn.to_dict()
+
+    print(stn_dict)
+    print(type(stn_dict['nodes'][0]['data']))

--- a/test/test_dsc.py
+++ b/test/test_dsc.py
@@ -36,9 +36,9 @@ class TestDSC(unittest.TestCase):
         self.logger.info("STNU: \n %s", self.stn)
 
         self.logger.info("Getting Schedule...")
-        risk_metric, schedule = self.stp.solve(self.stn)
+        schedule = self.stp.solve(self.stn)
 
-        self.logger.info("DSC: %s ", risk_metric)
+        self.logger.info("DSC: %s ", schedule.risk_metric)
         self.logger.info("schedule: %s ", schedule)
 
         completion_time = schedule.get_completion_time()
@@ -51,7 +51,7 @@ class TestDSC(unittest.TestCase):
         self.assertEqual(makespan, 98)
 
         expected_risk_metric = 0.0
-        self.assertEqual(risk_metric, expected_risk_metric)
+        self.assertEqual(schedule.risk_metric, expected_risk_metric)
 
         constraints = schedule.get_constraints()
 

--- a/test/test_fpc.py
+++ b/test/test_fpc.py
@@ -34,7 +34,7 @@ class TestFPC(unittest.TestCase):
     def test_build_stn(self):
         self.logger.info("STN: \n %s", self.stn)
 
-        metric, minimal_network = self.stp.solve(self.stn)
+        minimal_network = self.stp.solve(self.stn)
 
         self.logger.info("Minimal STN: \n %s", minimal_network)
 

--- a/test/test_srea.py
+++ b/test/test_srea.py
@@ -38,79 +38,79 @@ class TestSREA(unittest.TestCase):
         self.logger.info("PSTN: \n %s", self.stn)
 
         self.logger.info("Getting GUIDE...")
-        alpha, guide_stn = self.stp.solve(self.stn)
+        dispatchable_graph = self.stp.solve(self.stn)
         self.logger.info("GUIDE")
-        self.logger.info(guide_stn)
-        self.logger.info("Alpha: %s ", alpha)
+        self.logger.info(dispatchable_graph)
+        self.logger.info("Risk metric: %s ", dispatchable_graph.risk_metric)
 
-        completion_time = guide_stn.get_completion_time()
-        makespan = guide_stn.get_makespan()
+        completion_time = dispatchable_graph.get_completion_time()
+        makespan = dispatchable_graph.get_makespan()
         self.logger.info("Completion time: %s ", completion_time)
         self.logger.info("Makespan: %s ", makespan)
 
         self.assertEqual(completion_time, 60)
         self.assertEqual(makespan, 97)
 
-        expected_alpha = 0.0
-        self.assertEqual(alpha, expected_alpha)
+        expected_risk_metric = 0.0
+        self.assertEqual(dispatchable_graph.risk_metric, expected_risk_metric)
 
-        constraints = guide_stn.get_constraints()
+        constraints = dispatchable_graph.get_constraints()
 
         for (i, j) in constraints:
 
             if i == 0 and j == 1:
-                lower_bound = -guide_stn[j][i]['weight']
-                upper_bound = guide_stn[i][j]['weight']
+                lower_bound = -dispatchable_graph[j][i]['weight']
+                upper_bound = dispatchable_graph[i][j]['weight']
                 self.assertEqual(lower_bound, 37)
                 self.assertEqual(upper_bound, 38)
             if i == 0 and j == 2:
-                lower_bound = -guide_stn[j][i]['weight']
-                upper_bound = guide_stn[i][j]['weight']
+                lower_bound = -dispatchable_graph[j][i]['weight']
+                upper_bound = dispatchable_graph[i][j]['weight']
                 self.assertEqual(lower_bound, 41)
                 self.assertEqual(upper_bound, 47)
             if i == 0 and j == 3:
-                lower_bound = -guide_stn[j][i]['weight']
-                upper_bound = guide_stn[i][j]['weight']
+                lower_bound = -dispatchable_graph[j][i]['weight']
+                upper_bound = dispatchable_graph[i][j]['weight']
                 self.assertEqual(lower_bound, 42)
                 self.assertEqual(upper_bound, 54)
             if i == 0 and j == 4:
-                lower_bound = -guide_stn[j][i]['weight']
-                upper_bound = guide_stn[i][j]['weight']
+                lower_bound = -dispatchable_graph[j][i]['weight']
+                upper_bound = dispatchable_graph[i][j]['weight']
                 self.assertEqual(lower_bound, 92)
                 self.assertEqual(upper_bound, 94)
             if i == 0 and j == 5:
-                lower_bound = -guide_stn[j][i]['weight']
-                upper_bound = guide_stn[i][j]['weight']
+                lower_bound = -dispatchable_graph[j][i]['weight']
+                upper_bound = dispatchable_graph[i][j]['weight']
                 self.assertEqual(lower_bound, 96)
                 self.assertEqual(upper_bound, 102)
             if i == 0 and j == 6:
-                lower_bound = -guide_stn[j][i]['weight']
-                upper_bound = guide_stn[i][j]['weight']
+                lower_bound = -dispatchable_graph[j][i]['weight']
+                upper_bound = dispatchable_graph[i][j]['weight']
                 self.assertEqual(lower_bound, 97)
                 self.assertEqual(upper_bound, 109)
             if i == 1 and j == 2:
-                lower_bound = -guide_stn[j][i]['weight']
-                upper_bound = guide_stn[i][j]['weight']
+                lower_bound = -dispatchable_graph[j][i]['weight']
+                upper_bound = dispatchable_graph[i][j]['weight']
                 self.assertEqual(lower_bound, 0)
                 self.assertEqual(upper_bound, 47)
             if i == 2 and j == 3:
-                lower_bound = -guide_stn[j][i]['weight']
-                upper_bound = guide_stn[i][j]['weight']
+                lower_bound = -dispatchable_graph[j][i]['weight']
+                upper_bound = dispatchable_graph[i][j]['weight']
                 self.assertEqual(lower_bound, 0)
                 self.assertEqual(upper_bound, 61)
             if i == 3 and j == 4:
-                lower_bound = -guide_stn[j][i]['weight']
-                upper_bound = guide_stn[i][j]['weight']
+                lower_bound = -dispatchable_graph[j][i]['weight']
+                upper_bound = dispatchable_graph[i][j]['weight']
                 self.assertEqual(lower_bound, 0)
                 self.assertEqual(upper_bound, 61)
             if i == 4 and j == 5:
-                lower_bound = -guide_stn[j][i]['weight']
-                upper_bound = guide_stn[i][j]['weight']
+                lower_bound = -dispatchable_graph[j][i]['weight']
+                upper_bound = dispatchable_graph[i][j]['weight']
                 self.assertEqual(lower_bound, 0)
                 self.assertEqual(upper_bound, 61)
             if i == 5 and j == 6:
-                lower_bound = -guide_stn[j][i]['weight']
-                upper_bound = guide_stn[i][j]['weight']
+                lower_bound = -dispatchable_graph[j][i]['weight']
+                upper_bound = dispatchable_graph[i][j]['weight']
                 self.assertEqual(lower_bound, 0)
                 self.assertEqual(upper_bound, MAX_FLOAT)
 

--- a/test/update_pstn.py
+++ b/test/update_pstn.py
@@ -1,5 +1,6 @@
 from stn.pstn.pstn import PSTN
 import unittest
+from stn.utils.uuid import from_str
 
 
 class Task(object):
@@ -17,7 +18,7 @@ class UpdatePSTN(unittest.TestCase):
 
     def setUp(self):
         task_1 = Task()
-        task_1.task_id = "616af00-ec3b-4ecd-ae62-c94a3703594c"
+        task_1.task_id = from_str("0616af00-ec3b-4ecd-ae62-c94a3703594c")
         task_1.r_earliest_navigation_start_time = 0.0
         task_1.r_earliest_start_time = 96.0
         task_1.r_latest_start_time = 102.0
@@ -25,7 +26,7 @@ class UpdatePSTN(unittest.TestCase):
         task_1.finish_pose_name = "AMK_TDU-TGR-1_X_15.09_Y_5.69"
 
         task_2 = Task()
-        task_2.task_id = "207cc8da-2f0e-4538-802b-b8f3954df38d"
+        task_2.task_id = from_str("207cc8da-2f0e-4538-802b-b8f3954df38d")
         task_2.r_earliest_navigation_start_time = 0.0
         task_2.r_earliest_start_time = 71.0
         task_2.r_latest_start_time = 76.0
@@ -33,7 +34,7 @@ class UpdatePSTN(unittest.TestCase):
         task_2.finish_pose_name = "AMK_TDU-TGR-1_X_6.67_Y_14.52"
 
         task_3 = Task()
-        task_3.task_id = "0d06fb90-a76d-48b4-b64f-857b7388ab70"
+        task_3.task_id = from_str("0d06fb90-a76d-48b4-b64f-857b7388ab70")
         task_3.r_earliest_navigation_start_time = 0.0
         task_3.r_earliest_start_time = 41.0
         task_3.r_latest_start_time = 47.0

--- a/test/update_pstn.py
+++ b/test/update_pstn.py
@@ -5,7 +5,7 @@ import unittest
 class Task(object):
 
     def __init__(self):
-        self.id = ''
+        self.task_id = ''
         self.earliest_start_time = -1
         self.latest_start_time = -1
         self.start_pose_name = ''
@@ -17,7 +17,7 @@ class UpdatePSTN(unittest.TestCase):
 
     def setUp(self):
         task_1 = Task()
-        task_1.id = "616af00-ec3b-4ecd-ae62-c94a3703594c"
+        task_1.task_id = "616af00-ec3b-4ecd-ae62-c94a3703594c"
         task_1.r_earliest_navigation_start_time = 0.0
         task_1.r_earliest_start_time = 96.0
         task_1.r_latest_start_time = 102.0
@@ -25,7 +25,7 @@ class UpdatePSTN(unittest.TestCase):
         task_1.finish_pose_name = "AMK_TDU-TGR-1_X_15.09_Y_5.69"
 
         task_2 = Task()
-        task_2.id = "207cc8da-2f0e-4538-802b-b8f3954df38d"
+        task_2.task_id = "207cc8da-2f0e-4538-802b-b8f3954df38d"
         task_2.r_earliest_navigation_start_time = 0.0
         task_2.r_earliest_start_time = 71.0
         task_2.r_latest_start_time = 76.0
@@ -33,7 +33,7 @@ class UpdatePSTN(unittest.TestCase):
         task_2.finish_pose_name = "AMK_TDU-TGR-1_X_6.67_Y_14.52"
 
         task_3 = Task()
-        task_3.id = "0d06fb90-a76d-48b4-b64f-857b7388ab70"
+        task_3.task_id = "0d06fb90-a76d-48b4-b64f-857b7388ab70"
         task_3.r_earliest_navigation_start_time = 0.0
         task_3.r_earliest_start_time = 41.0
         task_3.r_latest_start_time = 47.0

--- a/test/update_stn.py
+++ b/test/update_stn.py
@@ -1,5 +1,6 @@
 from stn.stn import STN
 import unittest
+from stn.utils.uuid import from_str
 
 
 class Task(object):
@@ -17,7 +18,7 @@ class UpdateSTN(unittest.TestCase):
 
     def setUp(self):
         task_1 = Task()
-        task_1.task_id = "616af00-ec3b-4ecd-ae62-c94a3703594c"
+        task_1.task_id = from_str("0616af00-ec3b-4ecd-ae62-c94a3703594c")
         task_1.r_earliest_navigation_start_time = 0.0
         task_1.r_earliest_start_time = 96.0
         task_1.r_latest_start_time = 102.0
@@ -25,7 +26,7 @@ class UpdateSTN(unittest.TestCase):
         task_1.finish_pose_name = "AMK_TDU-TGR-1_X_15.09_Y_5.69"
 
         task_2 = Task()
-        task_2.task_id = "207cc8da-2f0e-4538-802b-b8f3954df38d"
+        task_2.task_id = from_str("207cc8da-2f0e-4538-802b-b8f3954df38d")
         task_2.r_earliest_navigation_start_time = 0.0
         task_2.r_earliest_start_time = 71.0
         task_2.r_latest_start_time = 76.0
@@ -33,7 +34,7 @@ class UpdateSTN(unittest.TestCase):
         task_2.finish_pose_name = "AMK_TDU-TGR-1_X_6.67_Y_14.52"
 
         task_3 = Task()
-        task_3.task_id = "0d06fb90-a76d-48b4-b64f-857b7388ab70"
+        task_3.task_id = from_str("0d06fb90-a76d-48b4-b64f-857b7388ab70")
         task_3.r_earliest_navigation_start_time = 0.0
         task_3.r_earliest_start_time = 41.0
         task_3.r_latest_start_time = 47.0

--- a/test/update_stn.py
+++ b/test/update_stn.py
@@ -5,7 +5,7 @@ import unittest
 class Task(object):
 
     def __init__(self):
-        self.id = ''
+        self.task_id = ''
         self.earliest_start_time = -1
         self.latest_start_time = -1
         self.start_pose_name = ''
@@ -17,7 +17,7 @@ class UpdateSTN(unittest.TestCase):
 
     def setUp(self):
         task_1 = Task()
-        task_1.id = "616af00-ec3b-4ecd-ae62-c94a3703594c"
+        task_1.task_id = "616af00-ec3b-4ecd-ae62-c94a3703594c"
         task_1.r_earliest_navigation_start_time = 0.0
         task_1.r_earliest_start_time = 96.0
         task_1.r_latest_start_time = 102.0
@@ -25,7 +25,7 @@ class UpdateSTN(unittest.TestCase):
         task_1.finish_pose_name = "AMK_TDU-TGR-1_X_15.09_Y_5.69"
 
         task_2 = Task()
-        task_2.id = "207cc8da-2f0e-4538-802b-b8f3954df38d"
+        task_2.task_id = "207cc8da-2f0e-4538-802b-b8f3954df38d"
         task_2.r_earliest_navigation_start_time = 0.0
         task_2.r_earliest_start_time = 71.0
         task_2.r_latest_start_time = 76.0
@@ -33,7 +33,7 @@ class UpdateSTN(unittest.TestCase):
         task_2.finish_pose_name = "AMK_TDU-TGR-1_X_6.67_Y_14.52"
 
         task_3 = Task()
-        task_3.id = "0d06fb90-a76d-48b4-b64f-857b7388ab70"
+        task_3.task_id = "0d06fb90-a76d-48b4-b64f-857b7388ab70"
         task_3.r_earliest_navigation_start_time = 0.0
         task_3.r_earliest_start_time = 41.0
         task_3.r_latest_start_time = 47.0

--- a/test/update_stnu.py
+++ b/test/update_stnu.py
@@ -1,5 +1,6 @@
 from stn.stnu.stnu import STNU
 import unittest
+from stn.utils.uuid import from_str
 
 
 class Task(object):
@@ -17,7 +18,7 @@ class UpdateSTNU(unittest.TestCase):
 
     def setUp(self):
         task_1 = Task()
-        task_1.task_id = "616af00-ec3b-4ecd-ae62-c94a3703594c"
+        task_1.task_id = from_str("0616af00-ec3b-4ecd-ae62-c94a3703594c")
         task_1.r_earliest_navigation_start_time = 0.0
         task_1.r_earliest_start_time = 96.0
         task_1.r_latest_start_time = 102.0
@@ -25,7 +26,7 @@ class UpdateSTNU(unittest.TestCase):
         task_1.finish_pose_name = "AMK_TDU-TGR-1_X_15.09_Y_5.69"
 
         task_2 = Task()
-        task_2.task_id = "207cc8da-2f0e-4538-802b-b8f3954df38d"
+        task_2.task_id = from_str("207cc8da-2f0e-4538-802b-b8f3954df38d")
         task_2.r_earliest_navigation_start_time = 0.0
         task_2.r_earliest_start_time = 71.0
         task_2.r_latest_start_time = 76.0
@@ -33,7 +34,7 @@ class UpdateSTNU(unittest.TestCase):
         task_2.finish_pose_name = "AMK_TDU-TGR-1_X_6.67_Y_14.52"
 
         task_3 = Task()
-        task_3.task_id = "0d06fb90-a76d-48b4-b64f-857b7388ab70"
+        task_3.task_id = from_str("0d06fb90-a76d-48b4-b64f-857b7388ab70")
         task_3.r_earliest_navigation_start_time = 0.0
         task_3.r_earliest_start_time = 41.0
         task_3.r_latest_start_time = 47.0

--- a/test/update_stnu.py
+++ b/test/update_stnu.py
@@ -5,7 +5,7 @@ import unittest
 class Task(object):
 
     def __init__(self):
-        self.id = ''
+        self.task_id = ''
         self.earliest_start_time = -1
         self.latest_start_time = -1
         self.start_pose_name = ''
@@ -17,7 +17,7 @@ class UpdateSTNU(unittest.TestCase):
 
     def setUp(self):
         task_1 = Task()
-        task_1.id = "616af00-ec3b-4ecd-ae62-c94a3703594c"
+        task_1.task_id = "616af00-ec3b-4ecd-ae62-c94a3703594c"
         task_1.r_earliest_navigation_start_time = 0.0
         task_1.r_earliest_start_time = 96.0
         task_1.r_latest_start_time = 102.0
@@ -25,7 +25,7 @@ class UpdateSTNU(unittest.TestCase):
         task_1.finish_pose_name = "AMK_TDU-TGR-1_X_15.09_Y_5.69"
 
         task_2 = Task()
-        task_2.id = "207cc8da-2f0e-4538-802b-b8f3954df38d"
+        task_2.task_id = "207cc8da-2f0e-4538-802b-b8f3954df38d"
         task_2.r_earliest_navigation_start_time = 0.0
         task_2.r_earliest_start_time = 71.0
         task_2.r_latest_start_time = 76.0
@@ -33,7 +33,7 @@ class UpdateSTNU(unittest.TestCase):
         task_2.finish_pose_name = "AMK_TDU-TGR-1_X_6.67_Y_14.52"
 
         task_3 = Task()
-        task_3.id = "0d06fb90-a76d-48b4-b64f-857b7388ab70"
+        task_3.task_id = "0d06fb90-a76d-48b4-b64f-857b7388ab70"
         task_3.r_earliest_navigation_start_time = 0.0
         task_3.r_earliest_start_time = 41.0
         task_3.r_latest_start_time = 47.0


### PR DESCRIPTION
- node: Remove unused import
- utils: Add method to convert from str to uuid
- test/scheduling_srea: Fix call to stp.solve(), it returns a dispatchable graph 
- Fix access to Node attrs (attrs are objects and not dictionaries)
Before, the conversion of a json string to an stn (networkx graph) filled in the node attrs as dictionaries, therefore all methods accessed node attrs as entries in a dictionary
Problem: the task_id was a string and not an uuid object
Now, the from_json method returns an stn where node data is an object of type node.

Contains commits of #17 