### PR TITLE
Fix/consistency contingent timepoints

### DIFF
--- a/stn/config/config.py
+++ b/stn/config/config.py
@@ -147,10 +147,10 @@ class FullPathConsistency(object):
 stn_factory = STNFactory()
 stn_factory.register_stn('fpc', STN)
 stn_factory.register_stn('srea', PSTN)
-stn_factory.register_stn('dsc_lp', STNU)
+stn_factory.register_stn('dsc', STNU)
 
 stp_solver_factory = STPSolverFactory()
 stp_solver_factory.register_solver('fpc', FullPathConsistency)
 stp_solver_factory.register_solver('srea', StaticRobustExecution)
 stp_solver_factory.register_solver('drea', StaticRobustExecution)
-stp_solver_factory.register_solver('dsc_lp', DegreeStongControllability)
+stp_solver_factory.register_solver('dsc', DegreeStongControllability)

--- a/stn/methods/dsc_lp.py
+++ b/stn/methods/dsc_lp.py
@@ -22,6 +22,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import copy
 
 import pulp
 import sys
@@ -43,7 +44,7 @@ class DSC_LP(object):
     logger = logging.getLogger('stn.dsc_lp')
 
     def __init__(self, stnu):
-        self.stnu = stnu
+        self.stnu = copy.deepcopy(stnu)
         self.constraints = stnu.get_constraints()
         self.contingent_constraints = stnu.get_contingent_constraints()
         self.contingent_timepoints = stnu.get_contingent_timepoints()

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -333,7 +333,9 @@ class STN(nx.DiGraph):
         """The STN is not consistent if it has negative cycles"""
         consistent = True
         for node, nodes in shortest_path_array.items():
-            if not math.isclose(nodes[node], 0.0, abs_tol=1e-09):
+            # Check if the tolerance is too large. Maybe it is better to use
+            # only integers and change the resolution to seconds
+            if not math.isclose(nodes[node], 0.0, abs_tol=1e-01):
                 consistent = False
         return consistent
 

--- a/stn/stnu/stnu.py
+++ b/stn/stnu/stnu.py
@@ -91,12 +91,11 @@ class STNU(STN):
     def get_contingent_timepoints(self):
         """ Returns a list with the contingent (uncontrollable) timepoints in the STNU
         """
-        timepoints = list(self.nodes)
         contingent_timepoints = list()
 
         for (i, j, data) in self.edges.data():
             if self[i][j]['is_contingent'] is True and i < j:
-                contingent_timepoints.append(timepoints[j])
+                contingent_timepoints.append(j)
 
         return contingent_timepoints
 
@@ -123,7 +122,10 @@ class STNU(STN):
             self.logger.debug("Adding constraint: %s ", (i, j))
             if self.nodes[i]['data'].node_type == "start":
                 lower_bound, upper_bound = self.get_travel_time_bounded_duration(task)
-                self.add_constraint(i, j, lower_bound, upper_bound, is_contingent=True)
+                if lower_bound == upper_bound:
+                    self.add_constraint(i, j, 0, 0)
+                else:
+                    self.add_constraint(i, j, lower_bound, upper_bound, is_contingent=True)
 
             elif self.nodes[i]['data'].node_type == "pickup":
                 lower_bound, upper_bound = self.get_work_time_bounded_duration(task)

--- a/test/test_dsc.py
+++ b/test/test_dsc.py
@@ -29,7 +29,7 @@ class TestDSC(unittest.TestCase):
         # Convert the dict to a json string
         stnu_json = json.dumps(stnu_dict)
 
-        self.stp = STP('dsc_lp')
+        self.stp = STP('dsc')
         self.stn = self.stp.get_stn(stn_json=stnu_json)
 
     def test_build_stn(self):


### PR DESCRIPTION
- stn: Increment tolerance to evaluate a number equal to 0.0
-  Fix contingent timepoints and edges for STNU
If a contingent edge's upper bound is equal to its lower bound, make it a requirement edge
Fix get contingent timepoints. Do not use node list (it might be out of index), append an integer instead
