### PR TITLE
Fix intertimepoint constraint when estimated duration has no variation

### DIFF
--- a/stn/methods/fpc.py
+++ b/stn/methods/fpc.py
@@ -1,14 +1,12 @@
-import logging
-import networkx as nx
 import copy
 
+import networkx as nx
 
 """ Achieves full path consistency (fpc) by applying the Floyd Warshall algorithm to the STN"""
 
 
 def get_minimal_network(stn):
 
-    logger = logging.getLogger('stn.fpc')
     minimal_network = copy.deepcopy(stn)
 
     shortest_path_array = nx.floyd_warshall(stn)
@@ -16,5 +14,3 @@ def get_minimal_network(stn):
         # Get minimal stn by updating the edges of the stn to reflect the shortest path distances
         minimal_network.update_edges(shortest_path_array)
         return minimal_network
-    else:
-        logger.debug("The minimal network is inconsistent. STP could not be solved")

--- a/stn/methods/srea.py
+++ b/stn/methods/srea.py
@@ -103,7 +103,7 @@ def setUpLP(stn, decouple):
     return (bounds, deltas, prob)
 
 
-def srea(inputstn,
+def srea(stn,
          debug=False,
          debugLP=False,
          returnAlpha=True,
@@ -112,7 +112,7 @@ def srea(inputstn,
          ub=0.999):
 
     """ Runs the SREA algorithm on an input STN
-    @param inputstn The STN that we are running SREA on
+    @param stn The STN that we are running SREA on
     @param debug Print optional status messages about alpha levels
     @param debugLP Print optional status messages about each run of the LP
     @param lb The starting lower bound on alpha for the binary search
@@ -121,8 +121,6 @@ def srea(inputstn,
     @returns a tuple (alpha, outputstn) if there is a solution,
     or None if there is no solution
     """
-
-    stn = copy.deepcopy(inputstn)
 
     # dictionary of alphas for binary search
     alphas = {i: i / 1000.0 for i in range(1001)}

--- a/stn/methods/srea.py
+++ b/stn/methods/srea.py
@@ -55,7 +55,7 @@ def setUpLP(stn, decouple):
     bounds = {}
     deltas = {}
 
-    prob = pulp.LpProblem('PSTN Robust Execution LP', pulp.LpMaximize)
+    prob = pulp.LpProblem('PSTN_Robust_Execution_LP', pulp.LpMaximize)
 
     for (i, j) in stn.edges():
         weight = stn.get_edge_weight(i, j)
@@ -266,6 +266,8 @@ def srea_LP(inputstn,
     if debug:
         prob.writeLP('STN.lp')
         pulp.LpSolverDefault.msg = 10
+
+    pulp.LpSolverDefault.msg = 0
 
     # Based on https://stackoverflow.com/questions/27406858/pulp-solver-error
     # Sometimes pulp throws an exception instead of returning a problem with unfeasible status

--- a/stn/node.py
+++ b/stn/node.py
@@ -9,7 +9,7 @@ class Node(object):
         if isinstance(task_id, str):
             task_id = from_str(task_id)
         self.task_id = task_id
-        # The node can be of node_type zero_timepoint, start, pickup or delivery
+        # The node can be of node_type zero_timepoint, departure, start or finish
         self.node_type = node_type
         self.is_executed = is_executed
         self.action_id = kwargs.get("action_id")

--- a/stn/pstn/pstn.py
+++ b/stn/pstn/pstn.py
@@ -46,14 +46,14 @@ class PSTN(STN):
 
     def __str__(self):
         to_print = ""
-        for (i, j, data) in self.edges.data():
+        for (i, j, data) in sorted(self.edges.data()):
             if self.has_edge(j, i) and i < j:
                 # Constraints with the zero timepoint
                 if i == 0:
                     timepoint = self.nodes[j]['data']
                     lower_bound = -self[j][i]['weight']
                     upper_bound = self[i][j]['weight']
-                    to_print += "Timepoint {}: [{}, {}]".format(timepoint, lower_bound, upper_bound)
+                    to_print += "Timepoint {}: {} [{}, {}]".format(timepoint, j, lower_bound, upper_bound)
                     if timepoint.is_executed:
                         to_print += " Ex"
                 # Constraints between the other timepoints

--- a/stn/pstn/pstn.py
+++ b/stn/pstn/pstn.py
@@ -150,6 +150,20 @@ class PSTN(STN):
                 # wait time between finish of one task and departure of the next one. Fixed to [0, inf]
                 self.add_constraint(i, j)
 
+    def update_travel_time(self, task):
+        position = self.get_task_position(task.task_id)
+        departure_node_id = 2 * position + (position-2)
+        start_node_id = departure_node_id + 1
+        distribution = self.get_travel_time_distribution(task)
+
+        if self.has_edge(departure_node_id, start_node_id):
+            if distribution.endswith("_0.0"):  # the distribution has no variation (stdev is 0)
+                # Make the constraint a requirement constraint
+                mean = float(distribution.split("_")[1])
+                self.add_constraint(departure_node_id, start_node_id, mean, mean)
+            else:
+                self.add_constraint(departure_node_id, start_node_id, distribution=distribution)
+
     @staticmethod
     def get_travel_time_distribution(task):
         travel_time = task.get_edge("travel_time")

--- a/stn/pstn/pstn.py
+++ b/stn/pstn/pstn.py
@@ -93,7 +93,7 @@ class PSTN(STN):
         """
 
         # The constraint is contingent if it has a probability distribution
-        is_contingent = distribution is not ""
+        is_contingent = distribution != ""
 
         super().add_constraint(i, j, wji, wij)
 

--- a/stn/pstn/pstn.py
+++ b/stn/pstn/pstn.py
@@ -115,9 +115,9 @@ class PSTN(STN):
     def add_intertimepoints_constraints(self, constraints, task):
         """ Adds constraints between the timepoints of a task
         Constraints between:
-        - start and pickup (contingent)
-        - pickup and delivery (contingent)
-        - delivery and next task (if any) (requirement)
+        - departure and start (contingent)
+        - start and finish (contingent)
+        - finish and next task (if any) (requirement)
         Args:
             constraints (list) : list of tuples that defines the pair of nodes between which a new constraint should be added
             Example:
@@ -128,7 +128,7 @@ class PSTN(STN):
         """
         for (i, j) in constraints:
             self.logger.debug("Adding constraint: %s ", (i, j))
-            if self.nodes[i]['data'].node_type == "start":
+            if self.nodes[i]['data'].node_type == "departure":
                 distribution = self.get_travel_time_distribution(task)
                 if distribution.endswith("_0.0"):  # the distribution has no variation (stdev is 0)
                     # Make the constraint a requirement constraint
@@ -137,7 +137,7 @@ class PSTN(STN):
                 else:
                     self.add_constraint(i, j, distribution=distribution)
 
-            elif self.nodes[i]['data'].node_type == "pickup":
+            elif self.nodes[i]['data'].node_type == "start":
                 distribution = self.get_work_time_distribution(task)
                 if distribution.endswith("_0.0"):  # the distribution has no variation (stdev is 0)
                     # Make the constraint a requirement constraint
@@ -146,8 +146,8 @@ class PSTN(STN):
                 else:
                     self.add_constraint(i, j, distribution=distribution)
 
-            elif self.nodes[i]['data'].node_type == "delivery":
-                # wait time between finish of one task and start of the next one. Fixed to [0, inf]
+            elif self.nodes[i]['data'].node_type == "finish":
+                # wait time between finish of one task and departure of the next one. Fixed to [0, inf]
                 self.add_constraint(i, j)
 
     @staticmethod

--- a/stn/pstn/pstn.py
+++ b/stn/pstn/pstn.py
@@ -53,7 +53,7 @@ class PSTN(STN):
                     timepoint = self.nodes[j]['data']
                     lower_bound = -self[j][i]['weight']
                     upper_bound = self[i][j]['weight']
-                    to_print += "Timepoint {}: {} [{}, {}]".format(timepoint, j, lower_bound, upper_bound)
+                    to_print += "Timepoint {}: [{}, {}]".format(timepoint, lower_bound, upper_bound)
                     if timepoint.is_executed:
                         to_print += " Ex"
                 # Constraints between the other timepoints

--- a/stn/pstn/pstn.py
+++ b/stn/pstn/pstn.py
@@ -164,6 +164,21 @@ class PSTN(STN):
             else:
                 self.add_constraint(departure_node_id, start_node_id, distribution=distribution)
 
+    def update_work_time(self, task):
+        position = self.get_task_position(task.task_id)
+        departure_node_id = 2 * position + (position-2)
+        start_node_id = departure_node_id + 1
+        finish_node_id = start_node_id + 1
+        distribution = self.get_work_time_distribution(task)
+
+        if self.has_edge(start_node_id, finish_node_id):
+            if distribution.endswith("_0.0"):  # the distribution has no variation (stdev is 0)
+                # Make the constraint a requirement constraint
+                mean = float(distribution.split("_")[1])
+                self.add_constraint(start_node_id, finish_node_id, mean, mean)
+            else:
+                self.add_constraint(start_node_id, finish_node_id, distribution=distribution)
+
     @staticmethod
     def get_travel_time_distribution(task):
         travel_time = task.get_edge("travel_time")

--- a/stn/pstn/pstn.py
+++ b/stn/pstn/pstn.py
@@ -139,7 +139,12 @@ class PSTN(STN):
 
             elif self.nodes[i]['data'].node_type == "pickup":
                 distribution = self.get_work_time_distribution(task)
-                self.add_constraint(i, j, distribution=distribution)
+                if distribution.endswith("_0.0"):  # the distribution has no variation (stdev is 0)
+                    # Make the constraint a requirement constraint
+                    mean = float(distribution.split("_")[1])
+                    self.add_constraint(i, j, mean, mean)
+                else:
+                    self.add_constraint(i, j, distribution=distribution)
 
             elif self.nodes[i]['data'].node_type == "delivery":
                 # wait time between finish of one task and start of the next one. Fixed to [0, inf]

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -532,6 +532,15 @@ class STN(nx.DiGraph):
 
         return _time
 
+    def get_times(self, task_id, node_type='departure'):
+        _time = None
+        for i, data in self.nodes.data():
+            if task_id == data['data'].task_id and data['data'].node_type == node_type:
+                lower_bound = -self[i][0]['weight']
+                upper_bound = self[0][i]['weight']
+                _time = (lower_bound, upper_bound)
+        return _time
+
     def get_node_earliest_time(self, node_id):
         return -self[node_id][0]['weight']
 

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -755,7 +755,11 @@ class STN(nx.DiGraph):
         stn = cls()
         dict_json = json.loads(stn_json)
         graph = json_graph.node_link_graph(dict_json)
-        stn.add_nodes_from([(i, {'data': Node.from_dict(graph.nodes[i]['data'])}) for i in graph.nodes()])
+        for i in graph.nodes():
+            if 'data' in graph.nodes[i]:
+                stn.add_node(i, data=Node.from_dict(graph.nodes[i]['data']))
+            else:
+                stn.add_node(i)
         stn.add_edges_from(graph.edges(data=True))
 
         return stn

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -539,7 +539,7 @@ class STN(nx.DiGraph):
         _time = None
         for i, data in self.nodes.data():
 
-            if task_id == data['data'].task_id and data['data'].node_type == node_type:
+            if 'data' in data and task_id == data['data'].task_id and data['data'].node_type == node_type:
                 if lower_bound:
                     _time = -self[i][0]['weight']
                 else:  # upper bound

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -391,18 +391,15 @@ class STN(nx.DiGraph):
                 tasks.append(self.nodes[i]['data'].task_id)
         return tasks
 
-    def get_insertion_points(self, r_earliest_time, r_latest_time):
-        """ Returns positions in the stn that have tasks whose earliest and latest times are
-        within the given earliest and latest time
-
+    def get_insertion_points(self, r_earliest_time):
+        """ Returns positions in the stn that have tasks whose latest start time are
+        are less or equal than the given earliest time
         """
         insertion_points = list()
         for i, data in self.nodes.data():
             if i == 0:   # ignore ztp
                 continue
-            if data['data'].node_type == "start" and \
-                (r_earliest_time <= -self[i][0]['weight'] or
-                 r_latest_time <= self[0][i]['weight']):
+            if data['data'].node_type == "start" and r_earliest_time <= self[0][i]['weight']:
                 task_position = math.ceil(i/3)
                 insertion_points.append(task_position)
         return insertion_points

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -485,7 +485,7 @@ class STN(nx.DiGraph):
         completion_time = 0
         task_ids = self.get_tasks()
         for i, task_id in enumerate(task_ids):
-            completion_time += self.get_time(task_id, "finish", lower_bound=False)
+            completion_time += self.get_time(task_id, "finish")
 
         return completion_time
 

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -254,6 +254,16 @@ class STN(nx.DiGraph):
         if self.has_edge(departure_node_id, start_node_id):
             self.add_constraint(departure_node_id, start_node_id, travel_time, travel_time)
 
+    def update_work_time(self, task):
+        position = self.get_task_position(task.task_id)
+        departure_node_id = 2 * position + (position-2)
+        start_node_id = departure_node_id + 1
+        finish_node_id = start_node_id + 1
+        work_time = self.get_work_time(task)
+
+        if self.has_edge(start_node_id, finish_node_id):
+            self.add_constraint(start_node_id, finish_node_id, work_time, work_time)
+
     @staticmethod
     def get_travel_time(task):
         """ Returns the mean of the travel time (time for going from current pose to start pose)

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -613,19 +613,19 @@ class STN(nx.DiGraph):
             if task_id == data['data'].task_id and data['data'].node_type == 'departure':
                 return math.ceil(i/3)
 
-    def get_earliest_task_id(self):
+    def get_earliest_task_id(self, node_type=None):
         """ Returns the id of the earliest task in the stn
 
         Returns: task_id (string)
         """
-        # The first task in the graph is the task with the earliest departure time
-        # The first task is in node 1, node 0 is reserved for the zero timepoint
-
-        if self.has_node(1):
-            task_id = self.nodes[1]['data'].task_id
-            return task_id
-
-        self.logger.debug("STN has no tasks yet")
+        # The first task in the graph is the task with the earliest time
+        # node 0 is reserved for the zero timepoint
+        for i, data in sorted(self.nodes.data()):
+            if i == 0:   # ignore ztp
+                continue
+            if node_type is None or \
+                    (node_type is not None and data['data'].node_type == node_type):
+                return data['data'].task_id
 
     def get_task_nodes(self, task_id):
         """ Gets the nodes in the stn associated with the given task_id

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -542,7 +542,7 @@ class STN(nx.DiGraph):
     def get_times(self, task_id, node_type='departure'):
         _time = None
         for i, data in self.nodes.data():
-            if task_id == data['data'].task_id and data['data'].node_type == node_type:
+            if 'data' in data and task_id == data['data'].task_id and data['data'].node_type == node_type:
                 lower_bound = -self[i][0]['weight']
                 upper_bound = self[0][i]['weight']
                 _time = (lower_bound, upper_bound)

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -245,6 +245,15 @@ class STN(nx.DiGraph):
                 # wait time between finish of one task and departure of the next one. Fixed to [0, inf]
                 self.add_constraint(i, j)
 
+    def update_travel_time(self, task):
+        position = self.get_task_position(task.task_id)
+        departure_node_id = 2 * position + (position-2)
+        start_node_id = departure_node_id + 1
+        travel_time = self.get_travel_time(task)
+
+        if self.has_edge(departure_node_id, start_node_id):
+            self.add_constraint(departure_node_id, start_node_id, travel_time, travel_time)
+
     @staticmethod
     def get_travel_time(task):
         """ Returns the mean of the travel time (time for going from current pose to start pose)

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -37,7 +37,7 @@ class STN(nx.DiGraph):
 
     def __str__(self):
         to_print = ""
-        for (i, j, data) in self.edges.data():
+        for (i, j, data) in sorted(self.edges.data()):
             if self.has_edge(j, i) and i < j:
                 # Constraints with the zero timepoint
                 if i == 0:
@@ -729,7 +729,7 @@ class STN(nx.DiGraph):
 
     def to_dict(self):
         stn = copy.deepcopy(self)
-        for i, data in self.nodes.data():
+        for i, data in sorted(self.nodes.data()):
             stn.nodes[i]['data'] = self.nodes[i]['data'].to_dict()
         stn_dict = json_graph.node_link_data(stn)
         return stn_dict

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -372,8 +372,8 @@ class STN(nx.DiGraph):
             if i == 0:   # ignore ztp
                 continue
             if data['data'].node_type == "start" and \
-                (r_earliest_time < -self[i][0]['weight'] or
-                 r_latest_time < self[0][i]['weight']):
+                (r_earliest_time <= -self[i][0]['weight'] or
+                 r_latest_time <= self[0][i]['weight']):
                 task_position = math.ceil(i/3)
                 insertion_points.append(task_position)
         return insertion_points

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -362,6 +362,22 @@ class STN(nx.DiGraph):
                 tasks.append(self.nodes[i]['data'].task_id)
         return tasks
 
+    def get_insertion_points(self, r_earliest_time, r_latest_time):
+        """ Returns positions in the stn that have tasks whose earliest and latest times are
+        within the given earliest and latest time
+
+        """
+        insertion_points = list()
+        for i, data in self.nodes.data():
+            if i == 0:   # ignore ztp
+                continue
+            if data['data'].node_type == "start" and \
+                (r_earliest_time < -self[i][0]['weight'] or
+                 r_latest_time < self[0][i]['weight']):
+                task_position = math.ceil(i/3)
+                insertion_points.append(task_position)
+        return insertion_points
+
     def is_consistent(self, shortest_path_array):
         """The STN is not consistent if it has negative cycles"""
         consistent = True

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -83,12 +83,12 @@ class STN(nx.DiGraph):
         self.add_node(0, data=node)
 
     def get_earliest_time(self):
-        edges = [e for e in self.edges]
+        edges = [e for e in sorted(self.edges)]
         first_edge = edges[0]
         return -self[first_edge[1]][0]['weight']
 
     def get_latest_time(self):
-        edges = [e for e in self.edges]
+        edges = [e for e in sorted(self.edges)]
         last_edge = edges[-1]
         return self[0][last_edge[0]]['weight']
 
@@ -566,7 +566,7 @@ class STN(nx.DiGraph):
 
     def get_nodes_by_task(self, task_id):
         nodes = list()
-        for node_id, data in self.nodes.data():
+        for node_id, data in sorted(self.nodes.data()):
             if data['data'].task_id == task_id:
                 node = (node_id, self.nodes[node_id]['data'])
                 nodes.append(node)
@@ -653,7 +653,7 @@ class STN(nx.DiGraph):
 
         """
         node_ids = list()
-        for i in self.nodes():
+        for i in sorted(self.nodes()):
             if task_id == self.nodes[i]['data'].task_id:
                 node_ids.append(i)
 

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -388,7 +388,9 @@ class STN(nx.DiGraph):
         """
         tasks = list()
         for i in self.nodes():
-            if self.nodes[i]['data'].task_id not in tasks and self.nodes[i]['data'].node_type != 'zero_timepoint':
+            if 'data' in self.nodes[i] and \
+                    self.nodes[i]['data'].task_id not in tasks and\
+                    self.nodes[i]['data'].node_type != 'zero_timepoint':
                 tasks.append(self.nodes[i]['data'].task_id)
         return tasks
 

--- a/stn/stnu/stnu.py
+++ b/stn/stnu/stnu.py
@@ -148,6 +148,19 @@ class STNU(STN):
             else:
                 self.add_constraint(departure_node_id, start_node_id, lower_bound, upper_bound, is_contingent=True)
 
+    def update_work_time(self, task):
+        position = self.get_task_position(task.task_id)
+        departure_node_id = 2 * position + (position-2)
+        start_node_id = departure_node_id + 1
+        finish_node_id = start_node_id + 1
+        lower_bound, upper_bound = self.get_work_time_bounded_duration(task)
+
+        if self.has_edge(start_node_id, finish_node_id):
+            if lower_bound == upper_bound:
+                self.add_constraint(start_node_id, finish_node_id, 0, 0)
+            else:
+                self.add_constraint(start_node_id, finish_node_id, lower_bound, upper_bound, is_contingent=True)
+
     @staticmethod
     def get_travel_time_bounded_duration(task):
         """ Returns the estimated travel time as a bounded interval

--- a/stn/stnu/stnu.py
+++ b/stn/stnu/stnu.py
@@ -108,7 +108,7 @@ class STNU(STN):
     def add_intertimepoints_constraints(self, constraints, task):
         """ Adds constraints between the timepoints of a task
         Constraints between:
-        - navigation start and start (contingent)
+        - departure and start (contingent)
         - start and finish (contingent)
         - finish and next task (if any) (requirement)
         Args:
@@ -121,19 +121,19 @@ class STNU(STN):
         """
         for (i, j) in constraints:
             self.logger.debug("Adding constraint: %s ", (i, j))
-            if self.nodes[i]['data'].node_type == "start":
+            if self.nodes[i]['data'].node_type == "departure":
                 lower_bound, upper_bound = self.get_travel_time_bounded_duration(task)
                 if lower_bound == upper_bound:
                     self.add_constraint(i, j, 0, 0)
                 else:
                     self.add_constraint(i, j, lower_bound, upper_bound, is_contingent=True)
 
-            elif self.nodes[i]['data'].node_type == "pickup":
+            elif self.nodes[i]['data'].node_type == "start":
                 lower_bound, upper_bound = self.get_work_time_bounded_duration(task)
                 self.add_constraint(i, j, lower_bound, upper_bound, is_contingent=True)
 
-            elif self.nodes[i]['data'].node_type == "delivery":
-                # wait time between finish of one task and start of the next one. Fixed to [0, inf]
+            elif self.nodes[i]['data'].node_type == "finish":
+                # wait time between finish of one task and departure of the next one. Fixed to [0, inf]
                 self.add_constraint(i, j, 0)
 
     @staticmethod

--- a/stn/stnu/stnu.py
+++ b/stn/stnu/stnu.py
@@ -161,6 +161,29 @@ class STNU(STN):
             else:
                 self.add_constraint(start_node_id, finish_node_id, lower_bound, upper_bound, is_contingent=True)
 
+    def remove_node_ids(self, node_ids, archived_stn=None):
+        # Assumes that the node_ids are in consecutive order from node_id 1 onwards
+        for i in node_ids:
+            if archived_stn:
+                # Start adding nodes after the last node_id in archived_stn
+                start_node_id = list(archived_stn.nodes())[-1]
+                if start_node_id == 0:  # skip the zero_timepoint
+                    start_node_id = 1
+                archived_stn.add_node(start_node_id, data=self.nodes[i]['data'])
+                archived_stn.add_edge(start_node_id, 0, weight=self[i][0]['weight'], is_executed=True)
+                archived_stn.add_edge(0, start_node_id, weight=self[0][i]['weight'], is_executed=True)
+
+                if self.has_edge(i, i+1):
+                    if self[i][i + 1]['is_contingent'] is True:
+                            archived_stn.add_constraint(start_node_id, start_node_id+1, -self[i+1][i]['weight'], self[i][i+1]['weight'], self[i][i+1]['distribution'])
+                    else:
+                        archived_stn.add_constraint(start_node_id, start_node_id+1, -self[i+1][i]['weight'], self[i][i+1]['weight'])
+                else:
+                    # Add dummy node
+                    archived_stn.add_node(start_node_id+1)
+            self.remove_node(i)
+        return archived_stn
+
     @staticmethod
     def get_travel_time_bounded_duration(task):
         """ Returns the estimated travel time as a bounded interval

--- a/stn/stnu/stnu.py
+++ b/stn/stnu/stnu.py
@@ -20,7 +20,7 @@ class STNU(STN):
 
     def __str__(self):
         to_print = ""
-        for (i, j, data) in self.edges.data():
+        for (i, j, data) in sorted(self.edges.data()):
             if self.has_edge(j, i) and i < j:
                 # Constraints with the zero timepoint
                 if i == 0:

--- a/stn/stnu/stnu.py
+++ b/stn/stnu/stnu.py
@@ -136,6 +136,18 @@ class STNU(STN):
                 # wait time between finish of one task and departure of the next one. Fixed to [0, inf]
                 self.add_constraint(i, j, 0)
 
+    def update_travel_time(self, task):
+        position = self.get_task_position(task.task_id)
+        departure_node_id = 2 * position + (position-2)
+        start_node_id = departure_node_id + 1
+        lower_bound, upper_bound = self.get_travel_time_bounded_duration(task)
+
+        if self.has_edge(departure_node_id, start_node_id):
+            if lower_bound == upper_bound:
+                self.add_constraint(departure_node_id, start_node_id, 0, 0)
+            else:
+                self.add_constraint(departure_node_id, start_node_id, lower_bound, upper_bound, is_contingent=True)
+
     @staticmethod
     def get_travel_time_bounded_duration(task):
         """ Returns the estimated travel time as a bounded interval

--- a/stn/task.py
+++ b/stn/task.py
@@ -44,7 +44,7 @@ class Timepoint(AsDictMixin):
 
 
 class Task(AsDictMixin):
-    def __init__(self, task_id, timepoints, edges, pickup_action_id, delivery_action_id):
+    def __init__(self, task_id, timepoints, edges, start_action_id, finish_action_id):
 
         """ Constructor for the Task object
 
@@ -52,14 +52,14 @@ class Task(AsDictMixin):
             task_id (UUID): An instance of an UUID object
             timepoints (list): list of timepoints (Timepoints)
             Edges (list): list of edges (Edges)
-            pickup_action_id (UUID): Action id of the pickup action
-            delivery_action_id (UUID): Action id of te delivery action
+            start_action_id (UUID): Action id linked to the start timepoint
+            finish_action_id (UUID): Action id linkted to the finish timepoint
         """
         self.task_id = task_id
         self.timepoints = timepoints
         self.edges = edges
-        self.pickup_action_id = pickup_action_id
-        self.delivery_action_id = delivery_action_id
+        self.start_action_id = start_action_id
+        self.finish_action_id = finish_action_id
 
     def __str__(self):
         to_print = ""
@@ -70,8 +70,8 @@ class Task(AsDictMixin):
         to_print += "\n Edges: \n"
         for edge in self.edges:
             to_print += str(edge) + "\t"
-        to_print += "\n Pickup action:" + str(self.pickup_action_id)
-        to_print += "\n Delivery action:" + str(self.delivery_action_id)
+        to_print += "\n Start action:" + str(self.start_action_id)
+        to_print += "\n Finish action:" + str(self.finish_action_id)
         return to_print
 
     def get_timepoint(self, timepoint_name):

--- a/stn/utils/as_dict.py
+++ b/stn/utils/as_dict.py
@@ -44,7 +44,7 @@ class AsDictMixin:
 
     @classmethod
     def _get_value(cls, key, value):
-        if key in ['task_id', 'pickup_action_id', 'delivery_action_id']:
+        if key in ['task_id', 'start_action_id', 'finish_action_id']:
             return from_str(value)
         else:
             return value

--- a/stn/utils/utils.py
+++ b/stn/utils/utils.py
@@ -24,13 +24,13 @@ def load_yaml(file):
 
 def create_task(stn, task_dict):
     task_id = task_dict.get("task_id")
-    r_earliest_pickup = task_dict.get("earliest_pickup")
-    r_latest_pickup = task_dict.get("latest_pickup")
+    r_earliest_start = task_dict.get("earliest_start")
+    r_latest_start = task_dict.get("latest_start")
     travel_time = Edge(**task_dict.get("travel_time"))
     work_time = Edge(**task_dict.get("work_time"))
-    timepoint_constraints = stn.create_timepoint_constraints(r_earliest_pickup, r_latest_pickup, travel_time, work_time)
+    timepoint_constraints = stn.create_timepoint_constraints(r_earliest_start, r_latest_start, travel_time, work_time)
     inter_timepoint_constraints = [travel_time, work_time]
-    pickup_action_id = generate_uuid()
-    delivery_action_id = generate_uuid()
+    start_action_id = generate_uuid()
+    finish_action_id = generate_uuid()
 
-    return Task(task_id, timepoint_constraints, inter_timepoint_constraints, pickup_action_id, delivery_action_id)
+    return Task(task_id, timepoint_constraints, inter_timepoint_constraints, start_action_id, finish_action_id)

--- a/test/data/pstn_two_tasks.json
+++ b/test/data/pstn_two_tasks.json
@@ -195,7 +195,7 @@
          "data":{
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
             "pose":"",
-            "node_type":"start"
+            "node_type":"departure"
          }
       },
       {
@@ -203,7 +203,7 @@
          "data":{
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
             "pose":"AMK_TDU-TGR-1_X_9.7_Y_5.6",
-            "node_type":"pickup"
+            "node_type":"start"
          }
       },
       {
@@ -211,7 +211,7 @@
          "data":{
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
             "pose":"AMK_TDU-TGR-1_X_5.82_Y_6.57",
-            "node_type":"delivery"
+            "node_type":"finish"
          }
       },
       {
@@ -219,7 +219,7 @@
          "data":{
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
             "pose":"",
-            "node_type":"start"
+            "node_type":"departure"
          }
       },
       {
@@ -227,7 +227,7 @@
          "data":{
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
             "pose":"AMK_TDU-TGR-1_X_14.03_Y_9.55",
-            "node_type":"pickup"
+            "node_type":"start"
          }
       },
       {
@@ -235,7 +235,7 @@
          "data":{
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
             "pose":"AMK_TDU-TGR-1_X_15.09_Y_5.69",
-            "node_type":"delivery"
+            "node_type":"finish"
          }
       }
    ],

--- a/test/data/stn_two_tasks.json
+++ b/test/data/stn_two_tasks.json
@@ -150,7 +150,7 @@
       {
          "data":{
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
-            "node_type":"start",
+            "node_type":"departure",
             "pose":""
          },
          "id":1
@@ -158,7 +158,7 @@
       {
          "data":{
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
-            "node_type":"pickup",
+            "node_type":"start",
             "pose":"AMK_TDU-TGR-1_X_9.7_Y_5.6"
          },
          "id":2
@@ -166,7 +166,7 @@
       {
          "data":{
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
-            "node_type":"delivery",
+            "node_type":"finish",
             "pose":"AMK_TDU-TGR-1_X_5.82_Y_6.57"
          },
          "id":3
@@ -174,7 +174,7 @@
       {
          "data":{
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
-            "node_type":"start",
+            "node_type":"departure",
             "pose":""
          },
          "id":4
@@ -182,7 +182,7 @@
       {
          "data":{
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
-            "node_type":"pickup",
+            "node_type":"start",
             "pose":"AMK_TDU-TGR-1_X_14.03_Y_9.55"
          },
          "id":5
@@ -190,7 +190,7 @@
       {
          "data":{
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
-            "node_type":"delivery",
+            "node_type":"finish",
             "pose":"AMK_TDU-TGR-1_X_15.09_Y_5.69"
          },
          "id":6

--- a/test/data/stnu_two_tasks.json
+++ b/test/data/stnu_two_tasks.json
@@ -10,7 +10,7 @@
       },
       {
          "data":{
-            "node_type":"start",
+            "node_type":"departure",
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
             "pose":""
          },
@@ -18,7 +18,7 @@
       },
       {
          "data":{
-            "node_type":"pickup",
+            "node_type":"start",
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
             "pose":"AMK_TDU-TGR-1_X_9.7_Y_5.6"
          },
@@ -26,7 +26,7 @@
       },
       {
          "data":{
-            "node_type":"delivery",
+            "node_type":"finish",
             "task_id":"0d06fb90-a76d-48b4-b64f-857b7388ab70",
             "pose":"AMK_TDU-TGR-1_X_5.82_Y_6.57"
          },
@@ -34,7 +34,7 @@
       },
       {
          "data":{
-            "node_type":"start",
+            "node_type":"departure",
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
             "pose":""
          },
@@ -42,7 +42,7 @@
       },
       {
          "data":{
-            "node_type":"pickup",
+            "node_type":"start",
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
             "pose":"AMK_TDU-TGR-1_X_14.03_Y_9.55"
          },
@@ -50,7 +50,7 @@
       },
       {
          "data":{
-            "node_type":"delivery",
+            "node_type":"finish",
             "task_id":"0616af00-ec3b-4ecd-ae62-c94a3703594c",
             "pose":"AMK_TDU-TGR-1_X_15.09_Y_5.69"
          },

--- a/test/data/tasks.yaml
+++ b/test/data/tasks.yaml
@@ -1,7 +1,7 @@
 0616af00-ec3b-4ecd-ae62-c94a3703594c:
   task_id: 0616af00-ec3b-4ecd-ae62-c94a3703594c
-  earliest_pickup: 10
-  latest_pickup: 20
+  earliest_start: 10
+  latest_start: 20
   travel_time:
     name: "travel_time"
     mean: 5
@@ -12,8 +12,8 @@
     variance: 0.2
 207cc8da-2f0e-4538-802b-b8f3954df38d:
   task_id: 207cc8da-2f0e-4538-802b-b8f3954df38d
-  earliest_pickup: 40
-  latest_pickup: 50
+  earliest_start: 40
+  latest_start: 50
   travel_time:
     name: "travel_time"
     mean: 5
@@ -24,8 +24,8 @@
     variance: 0.2
 0d06fb90-a76d-48b4-b64f-857b7388ab70:
   task_id: 0d06fb90-a76d-48b4-b64f-857b7388ab70
-  earliest_pickup: 70
-  latest_pickup: 80
+  earliest_start: 70
+  latest_start: 80
   travel_time:
     name: "travel_time"
     mean: 5


### PR DESCRIPTION
If the distribution has no variation (stdev is 0) the constraint should be a requirement constraint instead of a contingent constraint.

Before this was only done for the constraint between Start and Pickup, but it should also be done for the constraint between Pickup and Delivery.

<!--- Make the title descriptive! Think of the title as a one-line summary of your changes -->

<!-- Use this space to briefly explain *why* the changes are needed, and if it's the case, what the new components do differently -->

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

* Make the constraint a requirment constraint if the estimated duration between the tiempoints has no variation (sted is 0).
* Make the constraint a contingent constraint only if the estimated duration between the tiempoints has variation (sted is NOT 0).


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [`x` ] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [ ] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies. (does not apply)
- [ ] I have updated the documentation accordingly. (does not apply)

<!-- Click on the preview button to make sure everything is correctly formatted -->

